### PR TITLE
Added `.github/workflows/build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,40 +34,12 @@ jobs:
       - name: Build pack
         run: yarn pack
 
-      - name: Build AppImage (Ubuntu)
-        if: runner.os == 'Linux'
-        run: yarn appImage
-
-      - name: Build deb (Ubuntu)
-        if: runner.os == 'Linux'
-        run: yarn deb
-
-      - name: Build exe (Windows)
-        if: runner.os == 'Windows'
-        run: yarn win32
-
       - name: Upload pack (Ubuntu)
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lokinet-gui-ubuntu-pack
           path: release/linux-unpacked/**
-          if-no-files-found: error
-
-      - name: Upload AppImage (Ubuntu)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: lokinet-gui-ubuntu-appimage
-          path: release/*.AppImage
-          if-no-files-found: error
-
-      - name: Upload deb (Ubuntu)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: lokinet-gui-ubuntu-deb
-          path: release/*.deb
           if-no-files-found: error
 
       - name: Upload pack (Windows)
@@ -77,6 +49,34 @@ jobs:
           name: lokinet-gui-windows-pack
           path: release/win-unpacked/**
           if-no-files-found: error
+
+      - name: Build AppImage (Ubuntu)
+        if: runner.os == 'Linux'
+        run: yarn appImage
+
+      - name: Upload AppImage (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-ubuntu-appimage
+          path: release/*.AppImage
+          if-no-files-found: error
+
+      - name: Build deb (Ubuntu)
+        if: runner.os == 'Linux'
+        run: yarn deb
+
+      - name: Upload deb (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-ubuntu-deb
+          path: release/*.deb
+          if-no-files-found: error
+
+      - name: Build exe (Windows)
+        if: runner.os == 'Windows'
+        run: yarn win32
 
       - name: Upload exe (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,25 +31,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build pack
-        run: yarn pack
-
-      - name: Upload pack (Ubuntu)
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: lokinet-gui-ubuntu-pack
-          path: lokinet-gui-*.tgz
-          if-no-files-found: error
-
-      - name: Upload pack (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: lokinet-gui-windows-pack
-          path: lokinet-gui-*.tgz
-          if-no-files-found: error
-
       - name: Build AppImage (Ubuntu)
         if: runner.os == 'Linux'
         run: yarn appImage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            artifact_name: lokinet-gui-ubuntu-latest
-            artifact_path: |
-              release/linux-unpacked/**
-              release/*.AppImage
-              release/*.deb
-          - os: windows-latest
-            build_script: win32
-            artifact_name: lokinet-gui-windows-latest
-            artifact_path: |
-              release/win-unpacked/**
-              release/*portable.exe
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout code
@@ -54,13 +42,46 @@ jobs:
         if: runner.os == 'Linux'
         run: yarn deb
 
-      - name: Build (Windows)
+      - name: Build exe (Windows)
         if: runner.os == 'Windows'
-        run: yarn ${{ matrix.build_script }}
+        run: yarn win32
 
-      - name: Upload binaries
+      - name: Upload pack (Ubuntu)
+        if: runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.artifact_path }}
+          name: lokinet-gui-ubuntu-pack
+          path: release/linux-unpacked/**
+          if-no-files-found: error
+
+      - name: Upload AppImage (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-ubuntu-appimage
+          path: release/*.AppImage
+          if-no-files-found: error
+
+      - name: Upload deb (Ubuntu)
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-ubuntu-deb
+          path: release/*.deb
+          if-no-files-found: error
+
+      - name: Upload pack (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-windows-pack
+          path: release/win-unpacked/**
+          if-no-files-found: error
+
+      - name: Upload exe (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lokinet-gui-windows-exe
+          path: release/*portable.exe
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            build_script: appImage
             artifact_name: lokinet-gui-ubuntu-latest
-            artifact_path: release/*.AppImage
-          - os: macos-latest
-            build_script: macos
-            artifact_name: lokinet-gui-macos-latest
-            artifact_path: release/*.dmg
+            artifact_path: |
+              release/linux-unpacked/**
+              release/*.AppImage
+              release/*.deb
           - os: windows-latest
             build_script: win32
             artifact_name: lokinet-gui-windows-latest
-            artifact_path: release/*portable.exe
+            artifact_path: |
+              release/win-unpacked/**
+              release/*portable.exe
 
     steps:
       - name: Checkout code
@@ -37,19 +37,25 @@ jobs:
         with:
           node-version: 16.13.0
 
-      - name: Setup Python 3.11 (macOS)
-        if: runner.os == 'macOS'
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.11.9'
-
       - name: Setup Yarn
         run: npm install -g yarn@1.22.22
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Build
+      - name: Build pack
+        run: yarn pack
+
+      - name: Build AppImage (Ubuntu)
+        if: runner.os == 'Linux'
+        run: yarn appImage
+
+      - name: Build deb (Ubuntu)
+        if: runner.os == 'Linux'
+        run: yarn deb
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
         run: yarn ${{ matrix.build_script }}
 
       - name: Upload binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           node-version: 16.13.0
 
+      - name: Setup Python 3.11 (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11.9'
+
       - name: Setup Yarn
         run: npm install -g yarn@1.22.22
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lokinet-gui-ubuntu-pack
-          path: release/linux-unpacked/**
+          path: lokinet-gui-*.tgz
           if-no-files-found: error
 
       - name: Upload pack (Windows)
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: lokinet-gui-windows-pack
-          path: release/win-unpacked/**
+          path: lokinet-gui-*.tgz
           if-no-files-found: error
 
       - name: Build AppImage (Ubuntu)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ dev ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build for ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build lokinet-gui
+
+on:
+  push:
+    branches: [ dev ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            build_script: appImage
+            artifact_name: lokinet-gui-ubuntu-latest
+            artifact_path: release/*.AppImage
+          - os: macos-latest
+            build_script: macos
+            artifact_name: lokinet-gui-macos-latest
+            artifact_path: release/*.dmg
+          - os: windows-latest
+            build_script: win32
+            artifact_name: lokinet-gui-windows-latest
+            artifact_path: release/*portable.exe
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 16.13.0
+
+      - name: Setup Yarn
+        run: npm install -g yarn@1.22.22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn ${{ matrix.build_script }}
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+          if-no-files-found: error


### PR DESCRIPTION
Added `build.yml` for building the app in GitHub Actions.

This can be used for achieving reproducible builds and for testing new changes, e.g. we could now update dependencies to ditch `gconf2` (#46) and test whether it builds or not.

It seems like the current version doesn't build on macOS due to outdated dependencies.

You can see a result of this workflow execution here: https://github.com/pasabanov/lokinet-gui/actions/runs/27702523963.