### PR TITLE
Fixed multiple warnings regarding type mismatch

### DIFF
--- a/src/app/components/LabelSubtleWithValue.tsx
+++ b/src/app/components/LabelSubtleWithValue.tsx
@@ -173,7 +173,7 @@ export const UpSpeedWithPillAndIcon = (): JSX.Element => {
       pillColor={theme.connectedVpnModeColor}
       icon={<UploadInlineIcon size="15px" />}
       label="Upload"
-      value={upSpeed}
+      value={String(upSpeed)}
     />
   );
 };
@@ -187,7 +187,7 @@ export const DownSpeedWithPillAndIcon = (): JSX.Element => {
       pillColor={theme.dangerColor}
       icon={<DownloadInlineIcon size="15px" />}
       label="Download"
-      value={downSpeed}
+      value={String(downSpeed)}
     />
   );
 };
@@ -214,7 +214,7 @@ export const UpSpeedWithIcon = (): JSX.Element => {
   return (
     <SpeedWithIcon
       label="Upload"
-      value={upSpeed}
+      value={String(upSpeed)}
       icon={
         <>
           <UploadInlineIcon size="1.2rem" />
@@ -231,7 +231,7 @@ export const DownSpeedWithIcon = (): JSX.Element => {
   return (
     <SpeedWithIcon
       label="Download"
-      value={downSpeed}
+      value={String(downSpeed)}
       icon={
         <>
           <DownloadInlineIcon size="1.2rem" />

--- a/src/app/components/tabs/MainTab.tsx
+++ b/src/app/components/tabs/MainTab.tsx
@@ -32,7 +32,7 @@ export const MainTab = (): JSX.Element => {
       >
         <RoutersStats
           activePaths={numPathsBuilt}
-          ratio={ratio}
+          ratio={String(ratio)}
           numRouters={numRoutersKnown}
         />
         <SpeedStats />


### PR DESCRIPTION
Ensured comversion to String and removed the following warnings: In LabelSubtleWithValue.tsx:
```
Type 'string | false' is not assignable to type 'string'.
  Type 'boolean' is not assignable to type 'string'.
The expected type comes from property 'value' which is declared here on type 'IntrinsicAttributes & { label: string; value: string; pillColor: string; icon: ReactNode; }'

Type 'string | false' is not assignable to type 'string'.
  Type 'boolean' is not assignable to type 'string'.
The expected type comes from property 'value' which is declared here on type 'IntrinsicAttributes & { label: string; value: string; pillColor: string; icon: ReactNode; }'

Type 'string | false' is not assignable to type 'string'.
  Type 'boolean' is not assignable to type 'string'.
The expected type comes from property 'value' which is declared here on type 'IntrinsicAttributes & { label: string; value: string; icon: ReactNode; }'

Type 'string | false' is not assignable to type 'string'.
  Type 'boolean' is not assignable to type 'string'.
The expected type comes from property 'value' which is declared here on type 'IntrinsicAttributes & { label: string; value: string; icon: ReactNode; }'
```

In MainTab.tsx:
```
Type 'string | number' is not assignable to type 'string'.
  Type 'number' is not assignable to type 'string'.
The expected type comes from property 'ratio' which is declared here on type 'IntrinsicAttributes & { numRouters: number; activePaths: number; ratio: string; }'
```