### PR TITLE
Removed trailing comma in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,5 +6,5 @@
                 "regenerator": true
             }
         ]
-    ],
+    ]
 }


### PR DESCRIPTION
Fixed warning: "Trailing comma".