### PR TITLE
Bumped target from es5 to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": ["dom", "es2015", "es2016", "es2017"],
     "allowJs": true,


### PR DESCRIPTION
Fixed warning: `Option 'target=ES5' is deprecated and will stop functioning in TypeScript 7.0. Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.`.