### PR TITLE
Removed some unused code and fixed a warning

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,20 +2,13 @@ import { configureStore } from '@reduxjs/toolkit';
 import { appLogsSlice } from '../features/appLogsSlice';
 import { statusSlice } from '../features/statusSlice';
 import { uiSlice } from '../features/uiStatusSlice';
-import logger from 'redux-logger';
-import thunkMiddleware from 'redux-thunk';
-
-const sharedMiddlewares = [thunkMiddleware];
 
 export const store = configureStore({
   reducer: {
     status: statusSlice.reducer,
     uiStatus: uiSlice.reducer,
     appLogsStatus: appLogsSlice.reducer
-  },
-  middleware: process.env.REDUX_LOGGER
-    ? [...sharedMiddlewares, process.env.REDUX_LOGGER && logger]
-    : [...sharedMiddlewares, thunkMiddleware]
+  }
 });
 
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/src/features/statusSlice.ts
+++ b/src/features/statusSlice.ts
@@ -1,6 +1,5 @@
 import { createSelector, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { cloneDeep, omit } from 'lodash';
-import { logLineToAppSide } from '../../ipcNode';
 import { StatusErrorType } from '../../sharedIpc';
 import { appendToAppLogsOutsideRedux } from '../app/app';
 import {
@@ -8,7 +7,7 @@ import {
   SpeedHistoryDataType
 } from '../app/components/tabs/SpeedChart';
 import { getSavedExitNodesFromSettings } from '../app/config';
-import { RootState, store } from '../app/store';
+import { RootState } from '../app/store';
 import {
   DaemonSummaryStatus,
   defaultDaemonSummaryStatus

--- a/src/features/thunk.ts
+++ b/src/features/thunk.ts
@@ -142,8 +142,6 @@ function updateExitsSaved(exitNode: string) {
   store.dispatch(updateExitsFromSettings(existingFromSettings));
 }
 
-const MAX_RETRY_TIMEOUT = 11000;
-
 export const turnExitOn = async (
   exitNode?: string,
   authCode?: string


### PR DESCRIPTION
- Removed unsed field `middleware` in store.ts.
  Some other code in this file became unused too and was also removed.
  This also fixed the following warning:
  ```
  Type '("" | Middleware<{}, any, Dispatch<AnyAction>>)[]' is not assignable to type 'Middlewares<{ status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }> | ((getDefaultMiddleware: CurriedGetDefaultMiddleware<...>) => Middlewares<...>) | undefined'.
  Type '("" | Middleware<{}, any, Dispatch<AnyAction>>)[]' is not assignable to type 'Middlewares<{ status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }>'.
    Type '"" | Middleware<{}, any, Dispatch<AnyAction>>' is not assignable to type 'Middleware<{}, { status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }, Dispatch<AnyAction>>'.
      Type 'string' is not assignable to type 'Middleware<{}, { status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }, Dispatch<AnyAction>>'.
  The expected type comes from property 'middleware' which is declared here on type 'ConfigureStoreOptions<{ status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }, AnyAction, Middlewares<{ status: SummaryStatusState; uiStatus: GeneralInfosState; appLogsStatus: AppLogsState; }>>'
  ```
- Removed unused import `import { logLineToAppSide } from '../../ipcNode';` in statusSlice.ts.
- Removed unused import `store` from `../app/store` in statusSlice.ts.
- Removed unused constant `MAX_RETRY_TIMEOUT`.